### PR TITLE
VMO-3449 allow nested context objects to be used in array functions

### DIFF
--- a/src/php/Evaluator/MemberNodeEvaluator.php
+++ b/src/php/Evaluator/MemberNodeEvaluator.php
@@ -5,6 +5,7 @@ namespace Viamo\Floip\Evaluator;
 use ArrayAccess;
 use Viamo\Floip\Evaluator\Exception\NodeEvaluatorException;
 use Viamo\Floip\Contract\ParsesFloip;
+use Viamo\Floip\Evaluator\MemberNodeEvaluator\MemberObject;
 use Viamo\Floip\Util\Arr;
 
 class MemberNodeEvaluator extends AbstractNodeEvaluator
@@ -41,13 +42,14 @@ class MemberNodeEvaluator extends AbstractNodeEvaluator
         }
 
         // at this point, we have a value associated with our key
-        // if it is a nested context, return its default value or JSON
+        // if it is a nested context, return its default value or a
+        // representation that, when coerced into a string, becomes JSON
         if (Arr::isArray($currentContext)) {
-            if ((is_array($currentContext) && Arr::isAssoc($currentContext)) || $currentContext instanceof ArrayAccess) {
+            if ((Arr::isArray($currentContext) && Arr::isAssoc($currentContext)) || $currentContext instanceof ArrayAccess) {
                 if (Arr::exists($currentContext, '__value__')) {
                     return $currentContext['__value__'];
                 }
-                return \json_encode($currentContext, \JSON_FORCE_OBJECT);
+                return new MemberObject($currentContext);
             }
         }
         return $currentContext;

--- a/src/php/Evaluator/MemberNodeEvaluator.php
+++ b/src/php/Evaluator/MemberNodeEvaluator.php
@@ -45,7 +45,7 @@ class MemberNodeEvaluator extends AbstractNodeEvaluator
         // if it is a nested context, return its default value or a
         // representation that, when coerced into a string, becomes JSON
         if (Arr::isArray($currentContext)) {
-            if ((Arr::isArray($currentContext) && Arr::isAssoc($currentContext)) || $currentContext instanceof ArrayAccess) {
+            if ((is_array($currentContext) && Arr::isAssoc($currentContext)) || $currentContext instanceof ArrayAccess) {
                 if (Arr::exists($currentContext, '__value__')) {
                     return $currentContext['__value__'];
                 }

--- a/src/php/Evaluator/MemberNodeEvaluator/MemberObject.php
+++ b/src/php/Evaluator/MemberNodeEvaluator/MemberObject.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Viamo\Floip\Evaluator\MemberNodeEvaluator;
+
+use ArrayObject;
+use JsonSerializable;
+
+/**
+ * Holds expression objects for further evaluation.
+ * This allows the object to be used as an object in certain evaluation contexts
+ * instead of just as a string.
+ * When coerced into a string, becomes a JSON string.
+ */
+class MemberObject extends ArrayObject implements JsonSerializable
+{
+    public function __toString() {
+        return \json_encode($this, \JSON_FORCE_OBJECT);
+    }
+
+    public function getIterator() {
+        return new MemberObjectIterator($this);
+    }
+
+    public function &offsetGet($index) {
+        $item = array_key_exists($index, $this->data) ? $this->data[$index] : null;
+        if (is_array($item) && \array_key_exists('__value__', $item)) {
+            return $item['__value__'];
+        }
+        return $item;
+    }
+
+    public function jsonSerialize() {
+        return $this->getArrayCopy();
+    }
+}

--- a/src/php/Evaluator/MemberNodeEvaluator/MemberObjectIterator.php
+++ b/src/php/Evaluator/MemberNodeEvaluator/MemberObjectIterator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Viamo\Floip\Evaluator\MemberNodeEvaluator;
+
+use ArrayIterator;
+
+/**
+ * This iterator will expose the '__value__' of child expression objects.
+ */
+class MemberObjectIterator extends ArrayIterator
+{
+    public function current() {
+        $current = parent::current();
+        if (\is_array($current) && array_key_exists('__value__', $current)) {
+            return $current['__value__'];
+        }
+        return $current;
+    }
+}

--- a/src/php/Evaluator/MethodNodeEvaluator/ArrayHandler.php
+++ b/src/php/Evaluator/MethodNodeEvaluator/ArrayHandler.php
@@ -2,6 +2,8 @@
 
 namespace Viamo\Floip\Evaluator\MethodNodeEvaluator;
 
+use Countable;
+use Traversable;
 use Viamo\Floip\Evaluator\Exception\MethodNodeException;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Contract\ArrayHandler as ArrayHandlerInterface;
 use Viamo\Floip\Evaluator\Node;
@@ -25,20 +27,27 @@ class ArrayHandler extends AbstractMethodHandler implements ArrayHandlerInterfac
         if ($array instanceof Node) {
             $array = $array->getValue();
         }
-        if (!is_array($array)) {
+        if (!(is_array($array) || $array instanceof Traversable)) {
             $type = \gettype($array);
-            throw new MethodNodeException("Can only perform IN on an array, got $type");
+            throw new MethodNodeException("Can only perform IN on an array or Traversable, got $type");
         }
-        return in_array($value, $array);
+        // we can't just do in_array since we want to inspect the __value__ of
+        // object-like values
+        foreach ($array as $item) {
+            if ($item == $value) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function count($array) {
         if ($array instanceof Node) {
             $array = $array->getValue();
         }
-        if (!is_array($array)) {
+        if (!(is_array($array) || $array instanceof Countable)) {
             $type = \gettype($array);
-            throw new MethodNodeException("Can only perform COUNT on an array, got $type");
+            throw new MethodNodeException("Can only perform COUNT on an array or Countable, got $type");
         }
         return count($array);
     }

--- a/src/php/Evaluator/MethodNodeEvaluator/Contract/ArrayHandler.php
+++ b/src/php/Evaluator/MethodNodeEvaluator/Contract/ArrayHandler.php
@@ -17,7 +17,7 @@ interface ArrayHandler extends EvaluatesMethods
      * Determine whether a value is contained within an array.
      *
      * @param mixed $value
-     * @param array $array
+     * @param array|Traversable $array
      * @return bool
      */
     public function in($value, $array);
@@ -25,7 +25,7 @@ interface ArrayHandler extends EvaluatesMethods
 	/**
 	 * Count the number of elements in an array
 	 *
-	 * @param $array
+	 * @param array|Countable $array
 	 * @return int
 	 */
 	public function count($array);

--- a/tests/EvaluatorIntegrationTest.php
+++ b/tests/EvaluatorIntegrationTest.php
@@ -15,6 +15,7 @@ use Viamo\Floip\Evaluator\MethodNodeEvaluator;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Math;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Text;
 use Viamo\Floip\Evaluator\ConcatenationNodeEvaluator;
+use Viamo\Floip\Evaluator\MethodNodeEvaluator\ArrayHandler;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Logical;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\DateTime;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Excellent;
@@ -583,5 +584,31 @@ class EvaluatorIntegrationTest extends TestCase
                 "7 days from today is 2020-02-14 00:00:00",
             ]
         ];
+    }
+
+
+    public function testInGroupsNestedMemberObject() {
+        $e = "@(IN(groups.group, contact.groups))";
+        $c = [
+            'groups' => [
+                'group' => [
+                    '__value__' => 'group0'
+                ],
+                'group1'
+            ],
+            'contact' => [
+                'groups' => [
+                    'group0' => [
+                        '__value__' => 'group0'
+                    ],
+                    ['group1' => [
+                        '__value__' => 'group1'
+                    ]]
+                ]
+            ]
+                ];
+        $this->MethodNodeEvaluator->addHandler(new ArrayHandler);
+        $this->assertEquals('TRUE', $this->evaluator->evaluate($e, $c));
+        $this->assertEquals('2', $this->evaluator->evaluate('@(COUNT(contact.groups))', $c));
     }
 }


### PR DESCRIPTION
"@(IN(groups.group, contact.groups))"

This should work ,but doesn't because:
`contact.groups` is being coerced into a JSON string.

Solution:
Don't cast object-like values into JSON immediately, do it just-in-time.
Allow the object-like values to be iterated over and expose any child objects __value__

New test + old tests pass locally.