### PR TITLE
fix array handler dropping last argument

### DIFF
--- a/src/php/Evaluator/MethodNodeEvaluator/ArrayHandler.php
+++ b/src/php/Evaluator/MethodNodeEvaluator/ArrayHandler.php
@@ -19,8 +19,7 @@ class ArrayHandler extends AbstractMethodHandler implements ArrayHandlerInterfac
     }
 
     public function _array() {
-        // slice the args since the last is the eval context
-        return array_map([$this, 'value'], array_slice(func_get_args(), 0, -1));
+        return array_map([$this, 'value'], func_get_args());
     }
 
     public function in($value, $array) {

--- a/tests/Evaluator/MethodHandler/ArrayHandlerTest.php
+++ b/tests/Evaluator/MethodHandler/ArrayHandlerTest.php
@@ -20,8 +20,7 @@ class ArrayHandlerTest extends TestCase
 
     public function testConstructsArray() {
         $expected = ['abc', '123'];
-        $args = array_merge($expected, [[]]);
-        $actual = call_user_func_array([$this->arrayHandler, 'array'], $args);
+        $actual = call_user_func_array([$this->arrayHandler, 'array'], $expected);
 
         $this->assertEquals($expected, $actual);
     }
@@ -33,14 +32,14 @@ class ArrayHandlerTest extends TestCase
         $node2->setValue('123');
 
         $expected = ['abc', '123'];
-        $actual = call_user_func_array([$this->arrayHandler, 'array'], [$node1, $node2, []]);
+        $actual = call_user_func_array([$this->arrayHandler, 'array'], [$node1, $node2]);
 
         $this->assertEquals($expected, $actual);
     }
 
     public function testTrimsContextFromArgs() {
         $expected = [1, 2, 3];
-        $actual = \call_user_func_array([$this->arrayHandler, 'array'], [1, 2, 3, []]);
+        $actual = \call_user_func_array([$this->arrayHandler, 'array'], [1, 2, 3]);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/EvaluatorIntegrationTest.php
+++ b/tests/EvaluatorIntegrationTest.php
@@ -320,6 +320,11 @@ class EvaluatorIntegrationTest extends TestCase
                 [],
                 'foo, bar, baz'
             ],
+            'array to string, empty' => [
+                '@array()',
+                [],
+                ''
+            ],
             'in array, positive 1' => [
                 '@(in("baz", array("foo", "bar", "baz")))',
                 [],
@@ -335,10 +340,20 @@ class EvaluatorIntegrationTest extends TestCase
                 [],
                 'FALSE'
             ],
+            'in array, empty' => [
+                '@(in("foo", array()))',
+                [],
+                'FALSE',
+            ],
             'count' => [
                 '@(count(array("foo", "bar", "baz")))',
                 [],
                 '3'
+            ],
+            'count' => [
+                '@(count(array()))',
+                [],
+                '0'
             ]
         ];
     }

--- a/tests/EvaluatorIntegrationTest.php
+++ b/tests/EvaluatorIntegrationTest.php
@@ -303,6 +303,46 @@ class EvaluatorIntegrationTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @dataProvider arrayFunctionProvider
+     */
+    public function testArrayFunctions($expression, array $context, $expected) {
+        $this->MethodNodeEvaluator->addHandler(new ArrayHandler);
+        $result = $this->evaluator->evaluate($expression, $context);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function arrayFunctionProvider() {
+        return [
+            'array to string' => [
+                '@(array("foo", "bar", "baz"))',
+                [],
+                'foo, bar, baz'
+            ],
+            'in array, positive 1' => [
+                '@(in("baz", array("foo", "bar", "baz")))',
+                [],
+                'TRUE'
+            ],
+            'in array, positive 2' => [
+                '@(in("bar", array("foo", "bar", "baz")))',
+                [],
+                'TRUE'
+            ],
+            'in array, negative' => [
+                '@(in("fuz", array("foo", "bar", "baz")))',
+                [],
+                'FALSE'
+            ],
+            'count' => [
+                '@(count(array("foo", "bar", "baz")))',
+                [],
+                '3'
+            ]
+        ];
+    }
+
     public function nullExpressionProvider()
     {
         return [

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -151,13 +151,13 @@ class ParserTest extends TestCase
     private function mathNode($lhs, $rhs, $operator)
     {
         $type = 'MATH';
-        return compact('MATH', 'lhs', 'rhs', 'operator');
+        return compact('type', 'lhs', 'rhs', 'operator');
     }
 
     private function logicNode($lhs, $rhs, $operator)
     {
         $type = 'LOGIC';
-        return compact('MATH', 'lhs', 'rhs', 'operator');
+        return compact('type', 'lhs', 'rhs', 'operator');
     }
 
     public function plainStringProvider()


### PR DESCRIPTION
A previous commit removed the requirement to pass context method handlers.
The array handler was not updated, so it thinks the last argument it receives is the expression context -- which it then drops when performing functions.
This commit fixes that behavior and adds regression tests for it.