### PR TITLE
string comparisons should be case insensitive per spec

### DIFF
--- a/src/php/Evaluator/LogicNodeEvaluator.php
+++ b/src/php/Evaluator/LogicNodeEvaluator.php
@@ -49,6 +49,7 @@ class LogicNodeEvaluator extends AbstractNodeEvaluator
             if ($thing === '') {
                 return null;
             }
+            $thing = \strtolower($thing);
         }
         return $thing;
     }

--- a/tests/Evaluator/LogicNodeEvaluatorTest.php
+++ b/tests/Evaluator/LogicNodeEvaluatorTest.php
@@ -121,6 +121,15 @@ class LogicNodeEvaluatorTest extends TestCase
                     'operator' => '=',
                 ],
                 true
+            ],
+            [
+                [
+                    'type' => 'LOGIC',
+                    'lhs' => 'FOO',
+                    'rhs' => 'foo',
+                    'operator' => '=',
+                ],
+                true
             ]
         ];
     }


### PR DESCRIPTION
As per https://floip.gitbook.io/flow-specification/expressions#logical-comparisons

>Note that when comparing text values, the equals (=) and not-equals (<>) operators are case-insensitive.