### PR TITLE
CORE-419 add better error messages when evaluating nodes

### DIFF
--- a/src/php/Evaluator.php
+++ b/src/php/Evaluator.php
@@ -4,6 +4,8 @@ namespace Viamo\Floip;
 
 use ArrayAccess;
 use RecursiveIteratorIterator;
+use Throwable;
+use TypeError;
 use Viamo\Floip\Contract\EvaluatesExpression;
 use Viamo\Floip\Contract\ParsesFloip;
 use Viamo\Floip\Evaluator\Exception\EvaluatorException;
@@ -53,9 +55,14 @@ class Evaluator
         // since some nodes will have others as arguments
         $it = $this->getIterator($nodes);
         foreach ($it as $node) {
-            if ($node instanceof Node) {
-                $value = $this->evalNode($node, $context);
-                $node->setValue($value);
+            try {
+                if ($node instanceof Node) {
+                    $value = $this->evalNode($node, $context);
+                    $node->setValue($value);
+                }
+            } catch (Throwable $e) {
+                $jsonNode = \json_encode($node);
+                throw new EvaluatorException("Error in expression \"$expression\" at node $jsonNode", 0, $e);
             }
         }
 

--- a/src/php/Evaluator/Node.php
+++ b/src/php/Evaluator/Node.php
@@ -4,11 +4,12 @@ namespace Viamo\Floip\Evaluator;
 
 use ArrayAccess;
 use Exception;
+use JsonSerializable;
 use Stringable;
 use function implode;
 use function is_array;
 
-class Node implements ArrayAccess, Stringable {
+class Node implements ArrayAccess, Stringable, JsonSerializable {
 
     private array $data = [];
 
@@ -19,6 +20,10 @@ class Node implements ArrayAccess, Stringable {
     public function __construct($data)
     {
         $this->data = array_map([$this, 'transformData'], $data);
+    }
+
+    public function jsonSerialize(): mixed {
+        return $this->data;
     }
 
     /**

--- a/tests/EvaluatorIntegrationTest.php
+++ b/tests/EvaluatorIntegrationTest.php
@@ -17,6 +17,7 @@ use Viamo\Floip\Evaluator\MethodNodeEvaluator;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Math;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Text;
 use Viamo\Floip\Evaluator\ConcatenationNodeEvaluator;
+use Viamo\Floip\Evaluator\Exception\EvaluatorException;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\ArrayHandler;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\Logical;
 use Viamo\Floip\Evaluator\MethodNodeEvaluator\DateTime;
@@ -342,6 +343,15 @@ class EvaluatorIntegrationTest extends TestCase
         $expected   = '42 42 420 420';
 
         $this->assertEquals($expected, $this->evaluator->evaluate($expression, $context));
+    }
+
+    public function testWillThrowMeaningfulErrors() {
+        $context = ['bar' => ['a', 'b']];
+        $expression = "@contains('foo', bar)";
+
+        $this->expectException(EvaluatorException::class);
+        $this->expectExceptionMessageMatches("/@contains\('foo', bar\)/");
+        $this->evaluator->evaluate($expression, $context);
     }
 
     public function boolLogicProvider(): array {


### PR DESCRIPTION
It's pretty common for users to make errors when using expressions.
We should report these errors with more detail, especially when it's something like a TypeError.

Now we will get something like this:
"Error in expression "@contains('foo', bar)" at node {"type":"METHOD","call":"contains","args":["foo",{"type":"MEMBER","key":"bar","location":{"start":{"offset":17,"line":1,"column":18},"end":{"offset":20,"line":1,"column":21}}}],"chain":[],"location":{"start":{"offset":0,"line":1,"column":1},"end":{"offset":21,"line":1,"column":22}}}"

From this we can see that the error happens when evaluating CONTAINS specifically. In a longer expression, this will let us pinpoint where the problem is.

The originating TypeError is also preserved in the trace.